### PR TITLE
Specify using lower-hyphen-case in Sass code

### DIFF
--- a/css-styleguide.md
+++ b/css-styleguide.md
@@ -5,3 +5,17 @@ permalink: /css/
 ---
 
 In general, follow [Github's CSS styleguide](https://github.com/styleguide/css).
+
+## Use lower-hyphen-case for Variable and Mixin Names
+
+CSS properties already use lower-hyphen-case, so let's be consistent in our Sass.
+
+    // Not so good
+    $borderColor: $fafafa;
+    @mixin error_warning() {
+
+    // So good!
+    $border-color: $fafafa;
+    @mixin error-warning() {
+
+The only exception is if a library (like Bootstrap) includes their own mixins or variables.


### PR DESCRIPTION
Since CSS already uses this case, we should be consistent (we currently use lowerCamelCase, snake_case, *and* lower-hyphen-case for mixins!)

@armilam, @kpascascio: can I get an amen?