### PR TITLE
Added release notes page

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -6,6 +6,10 @@ permalink: /release-notes/
 
 Look here for recent updates to the Lesson.ly platform.
 
+### Coming Soon
+
+- Stuff
+
 ### Thursday, April 16, 2015, 12:58PM EST
 
 - Fixes a bug with triggers where a trigger would not be deleted when any of its releated users, groups, lessons, or courses were deleted

--- a/release-notes.md
+++ b/release-notes.md
@@ -8,7 +8,7 @@ Look here for recent updates to the Lesson.ly platform.
 
 ### Coming Soon
 
-- Stuff
+- Nothing yet!
 
 ### Thursday, April 16, 2015, 12:58PM EST
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,31 @@
+---
+layout: page
+title: Release Notes
+permalink: /release-notes/
+---
+
+Look here for recent updates to the Lesson.ly platform.
+
+### Thursday, April 16, 2015, 12:58PM EST
+
+- Fixes a bug with triggers where a trigger would not be deleted when any of its releated users, groups, lessons, or courses were deleted
+
+### Wednesday, April 15, 2015, 4:38PM EST
+
+- Fixed a bug that made it appear that previously answered questions were blank
+
+### Tuesday, April 14, 2015, 5:09PM EST
+
+- Enable lesson copying directly to another company
+- Admin interface updates
+
+### Tuesday, April 14, 2015, 10:00AM EST
+
+- Added triggers feature to enable automatic assignment upon completion of another assignment
+- Aggregate multiple choice answer data on lesson overview page
+- Fixed a bug that caused the back button on the edit lesson page to result in an error
+- Soft delete users to enable deleted user restoration
+
+### Monday, April 13, 2015, 9:40AM EST
+
+- Added configurability for SAML responses


### PR DESCRIPTION
So I'm thinking this is what the release notes page should look like. Feel free to provide any feedback!

Also, here's what I'm thinking for the process of adding to the release notes:

1. A PR by DevA is merged (in the app repo) by DevB
2. DevA checks out the `release-notes` branch in the documentation repo (this repo)
3. DevA adds a line under the "NEXT RELEASE" section in `release-notes.md` to describe what was added/changed/fixed in the app
4. DevA pushes the `release-notes` branch back up to github
5. Some time later (after maybe a few PRs), DevC pushes the app to production
6. DevC checks out the `release-notes` branch in the documentation repo
7. DevC changes the title "NEXT RELEASE" to the current date and time in `release-notes.md`
8. DevC merges `release-notes` into `master` and pushes `master` back up to github
9. DevC creates a new `release-notes` branch and adds a new "NEXT RELEASE" section in `release-notes.md`

Those steps should only happen when a PR is merged that should be announced publicly.

What do you think?

Fixes #8