### PR TITLE
Add to styleguide following latest code review

### DIFF
--- a/javascript-style-guide.md
+++ b/javascript-style-guide.md
@@ -4,6 +4,10 @@ title: JavaScript Style Guide
 permalink: /javascript/
 ---
 
+## General Guidelines
+
+- Put all JavaScript within `.js` or `.js.coffee` files (not `<script>` tags unless you have a good reason).
+
 ## Use lowerCamelCase
 
 For variable and function names in Javascript, use lowerCamelCase.
@@ -29,3 +33,5 @@ Use this:
 
     <input data-behavior="do_something">
     $('[data-behavior~=do_something]').doSomething();
+
+We've settled on lowercase with underscores (i.e. "snake_case") for `data-behavior` attributes.

--- a/ruby-styleguide.md
+++ b/ruby-styleguide.md
@@ -14,6 +14,7 @@ These override either Github’s or Batsov’s styleguide where applicable:
 
 - Use the Ruby 1.9-style hash syntax (`key: 'value'`) with symbol keys wherever possible. Only use `"hash" => "rocket"` syntax when hash keys are required to be strings.
 - Use a single newline above and below "private" and "protected" in classes
+- Use a single space within ERB tags, e.g. `<%= "foo" %>`, not `<%="foo"%>`
 
 ## Gemfile
 


### PR DESCRIPTION
A few undocumented conventions came up in the latest code review:

- JS in files, not `<script>` tags
- snake case for `data-behavior` atts
- space within ERB tags