### PR TITLE
Ruby style: use full words instead of letters for clarity

### DIFF
--- a/ruby-styleguide.md
+++ b/ruby-styleguide.md
@@ -15,6 +15,13 @@ These override either Github’s or Batsov’s styleguide where applicable:
 - Use the Ruby 1.9-style hash syntax (`key: 'value'`) with symbol keys wherever possible. Only use `"hash" => "rocket"` syntax when hash keys are required to be strings.
 - Use a single newline above and below "private" and "protected" in classes
 - Use a single space within ERB tags, e.g. `<%= "foo" %>`, not `<%="foo"%>`
+- Use full words for variables except where a single letter is conventional (e.g. `f` for Rails form objects, `i` for iterators, etc.).
+      
+      # not so clear
+      assignee.assignments.map(&:assignable).each { |a| ...
+      
+      # so clear!
+      assignee.assignments.map(&:assignable).each { |assignable| ...
 
 ## Gemfile
 


### PR DESCRIPTION
The particular bit of code that prompted this came from BulkAssignment.rb. Something like:

```ruby
@assignee.users.each do |user|
  assignables.map do |a|
    assignment = a.assign_to(user)
```

Here, we’re dealing with an assignee, assignables, and assignments, so it’s particularly unclear what `|a|` is referring to. But in general, I think this is a good practice. I’m surprised neither Bbatsov’s nor Github’s styleguides mention this, as I swear I’ve read it elsewhere.