### PR TITLE
Avoid mixing inline and multiline conditionals

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,3 +68,6 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 2.5)
+
+BUNDLED WITH
+   1.10.3

--- a/ruby-styleguide.md
+++ b/ruby-styleguide.md
@@ -22,6 +22,17 @@ These override either Github’s or Batsov’s styleguide where applicable:
       
       # so clear!
       assignee.assignments.map(&:assignable).each { |assignable| ...
+- Avoid mixing inline and multi-line conditionals: they hurt readability.
+      
+      # Easy to miss the second condition at the end
+      if some_condition
+        do_something_with_a_really_long_method_name if some_other_condition
+      end
+      
+      # It's easier to notice both conditions when they're in the same place
+      if some_condition && some_other_condition
+        do_something_with_a_really_long_method_name
+      end
 
 ## Gemfile
 


### PR DESCRIPTION
I noticed this one twice today. Since Github's preview doesn't parse our markdown right, here's how it looks:

![screen shot 2015-06-09 at 4 38 41 pm](https://cloud.githubusercontent.com/assets/664341/8069087/0bbea930-0ec6-11e5-8b4b-1588d6936849.png)
