### PR TITLE
Add Component-based CSS to CSS Stylegude

### DIFF
--- a/css-styleguide.md
+++ b/css-styleguide.md
@@ -4,7 +4,60 @@ title: CSS Style Guide
 permalink: /css/
 ---
 
-In general, follow [Github's CSS styleguide](https://github.com/styleguide/css).
+## Structure CSS Around Components
+
+Also called "object-oriented CSS", component-based CSS brings a number of benefits to customer and developer happiness (in the form of improved performance and maintainability). Fundamentally, it's about encapsulating styles into self-contained units. For example, here is some traditional CSS:
+
+    // app/stylesheets/lessons.scss
+    #lesson_viewer {
+      background: #eee;
+      h1 {
+        font-size: 2em;
+      }
+      &.past_due {
+        background: #f00;
+      }
+      &.expanded {
+        height: 400px;
+      }
+    }
+
+and here is how it would be written in a component-based way (using [SuitCSS naming conventions](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md)):
+
+    // app/stylesheets/components/lesson_viewer.scss
+    .LessonViewer {
+      background: #eee;
+    }
+    .LessonViewer-heading {
+      font-size: 2em;
+    }
+    .LessonViewer--pastDue {
+      background: #f00;
+    }
+    .LessonViewer.is-expanded {
+      height: 400px;
+    }
+
+### The Basics
+
+- Each component gets its own file within `stylesheets/components`.
+- We use **only class names**: ID selectors bring specificity headaches, and element selectors are inflexible when we need a different element.
+- The CSS is **flat**, with no nested classes, which improves rendering performance and reduces developer headaches when trying to override styles.
+- Instead of nesting, the class names themselves indicate hierarchy:
+  - the **component** itself has an upper-camel-cased class name, (e.g. `LessonViewer`).
+  - Class names for **elements within the component** begin with the component name followed by a hyphen, and then a lower-camel-cased name (e.g. `LessonViewer-heading`).
+  - Class names for **variations on a component** also begin with the component name followed by two hyphens, and then a lower-camel-cased name for the variation. Note that in the markup, the element with the `LessonViewer--pastDue` class also needs the base `LessonViewer` class.
+  - **Temporary states** like `.is-expanded` (which might be added by JavaScript based on user action) get their own class name, which begins with `is-` followed by a lower-camel-case name for the state. But their styles are always scoped to the component's class to avoid conflicts with other components that have an `is-expanded` state.
+
+### Pro Tips
+
+- Not everything should be a component:
+  - *Base styles* live within `stylesheets/global.scss` and affect the site as a whole. Avoid changing these unless you really intend to affect All Of The Things.
+  - *Utility classes* live within `stylesheets/utilities.scss` and define single-purpose classes (starting with `u-`, e.g. `u-clearFix`) for simple, reusable things like clearing floats.
+- Components can (and should!) contain other components. Just because a button is with an `.Element` component doesn't mean it must be `.Element-button`. If used elsewhere, make it its own `.Button` component.
+- Components can inherit from other components. For example, if you have an `.Element--question` variation that starts needing its own variations (e.g. for different question types), consider making it its own `.QuestionElement` component so it can have a `.QuestionElement--freeResponse` variation. Just be sure the markup contains the base component as well: `class="Element QuestionElement"`
+
+While these conventions are restrictive, this is intentional in order to keep the CSS simple. If you find yourself needing more complicated structures, consider how what you need might be broken up into multiple components.
 
 ## Use lower-hyphen-case for Variable and Mixin Names
 


### PR DESCRIPTION
This PR attempts to codify our use of component-based CSS (so that all the new CSS added by Studio Science will be consistent not with the hodgepodge we have, but the architecture we *want*). We already use CSS components in many places (just look in `app/assets/stylesheets/components`), but much of our CSS remains unintentional. In other words, with selectors as long and as specific as necessary, the length and specificity of which tends to escalate over time, leading to larger CSS file sizes, poorer rendering performance, and difficulty maintaining it. (For more on the downsides of unscalable CSS, [see my blog post](http://work.stevegrossi.com/2014/09/06/how-to-write-css-that-scales/).) This is how we get selectors like:

```css
article.lesson_editor > aside ul.lesson_sections > li.active .lesson_section_title
```

I'd like to make the case for doubling down on component-based CSS which would let this instead be simply

```css
.StackedNav-item--active
```

### SuitCSS

What this PR does introduce that's new is the set of [SuitCSS naming conventions](https://suitcss.github.io/) for components. This adds—at no cost—an extra layer of semantics to our component names. Currently we generally use hyphen-separated lowercase class names, e.g. `.progress-bar`. In this case, it's impossible to tell whether the component is `.progress` and this is its bar element, or this is the base `.progress-bar` component. With SuitCSS, this would be named `.Progress-bar` and we'd immediately know just by looking at the markup that this is the bar element within the `.Progress` component. We have to name things anyway: we might as well name them in such a way as to provide the greatest amount of context and direction to future developers. Twitter and [Medium](http://work.stevegrossi.com/2014/09/06/how-to-write-css-that-scales/) have begun using SuitCSS, and most apps these days are using some kind of component-based naming convention, if not SuitCSS then [BEM](https://en.bem.info/) or [SmaCSS](https://smacss.com/book/categorizing).