### PR TITLE
Prefer Time.current and Date.current

### DIFF
--- a/rails-styleguide.md
+++ b/rails-styleguide.md
@@ -71,3 +71,7 @@ ActiveRecord provides "bang" versions of methods like `create`, `update`, and `s
       flash.now.error "There was a problem updating your preference."
       render :edit
     end
+    
+### Time Zones
+
+Prefer `Time.current` and `Date.current` in place of `Time.now` and `Date.today`. The `.current` methods will properly take the `Time.zone` into account if set, which `.now` and `.today` do not, leading to inconsistent behavior.


### PR DESCRIPTION
As recommended by the companion [Rails styleguide](https://github.com/bbatsov/rails-style-guide#time) to our Ruby styleguide. We don't explicitly follow the Rails styleguide, but we've been bitten by edge cases around this enough times that it's worth explicitly following.