### PR TITLE
Add a recommendation to freeze strings which should not change

### DIFF
--- a/ruby-styleguide.md
+++ b/ruby-styleguide.md
@@ -44,6 +44,14 @@ These override either Github’s or Batsov’s styleguide where applicable:
       if current_user.present?
         # Do something
       end
+- `freeze` strings when their values should never change (e.g. in constants). It will make the string immutable, which has two advantages. It optimizes memory usage (because Ruby points to the same `String` object instead of instantiating a new `String` on each reference), and also prevents tempering, because in Ruby, constants aren't.
+      
+      DEFAULT_TITLE = "Untitled"
+      DEFAULT_TITLE << "foo"
+      DEFAULT_TITLE.inspect # => "Untitledfoo"
+      
+      DEFAULT_TITLE = "Untitled".freeze
+      DEFAULT_TITLE << "foo" # => RuntimeError: can't modify frozen string
 
 ## Service Objects
 


### PR DESCRIPTION
We sometimes do this, but it looks like a best-practice. Here's a great article from the Honeybadger team on when and why to `freeze`: http://blog.honeybadger.io/when-to-use-freeze-and-frozen-in-ruby