### PR TITLE
Don't reference instance variables in partials: prefer local variables

### DIFF
--- a/rails-styleguide.md
+++ b/rails-styleguide.md
@@ -34,7 +34,7 @@ While we don’t follow it explicitly, the [community Rails Styleguide](https://
 
 ### Views
 
-- Don't reference instance variables in partials. It's alright for `show.html` to reference the `@lesson` declared in `LessonsController#show`, but if it calls out to `render "stats"`, `stats.html` should not know about `@lesson`. Instead pass it in directly: `render "stats", lesson: @lesson`. Eventually, we'll want to use that partial in another context where `@lesson` isn't defined: being explicit now saves us time later.
+- Avoid referencing instance variables in partials. It's alright for `show.html.erb` to reference the `@lesson` declared in `LessonsController#show`, but if it calls out to `render "stats"`, `_stats.html.erb` should not know about `@lesson`. Instead pass it in directly: `render "stats", lesson: @lesson`. Eventually, we'll want to use that partial in another context where `@lesson` isn't defined: being explicit now saves us time later.
 
 ### ActiveRecord shortcuts
 

--- a/rails-styleguide.md
+++ b/rails-styleguide.md
@@ -32,6 +32,10 @@ While we don’t follow it explicitly, the [community Rails Styleguide](https://
       # so good!
       Model.joins("LEFT JOIN things ON thing_id = things.id AND another_id = things.another_id")
 
+### Views
+
+- Don't reference instance variables in partials. It's alright for `show.html` to reference the `@lesson` declared in `LessonsController#show`, but if it calls out to `render "stats"`, `stats.html` should not know about `@lesson`. Instead pass it in directly: `render "stats", lesson: @lesson`. Eventually, we'll want to use that partial in another context where `@lesson` isn't defined: being explicit now saves us time later.
+
 ### ActiveRecord shortcuts
 
 - Use `?` methods only for boolean values to avoid unexpected behavior. For example, ActiveRecord treats `0` as `false`, while Ruby treats `0` as a `true` value.


### PR DESCRIPTION
I'm running into this in the new overview pages: lessons and courses can share a lot of partials, but not when one expects `@lesson` and another expects `@course`. If these partials expected their dependencies to be passed in instead of magically being present, this would be simpler.

I think it's fine for a view template (e.g. `show.html.erb`) to reference instance vars (and be thus coupled) to its controller action, but it seems dangerous to couple *its own* dependents to the controller action as well.

```ruby
# Instead of
render "toolbar" # lessons/toolbar expects @lesson
render "toolbar" # courses/toolbar expects @course

# Use
render "shared/toolbar", resource: @lesson
render "shared/toolbar", resource: @course
```