### PR TITLE
Add a General Guidelines section, including not committing commented-out code

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ layout: default
 
 ## .editorconfig
 
-The app contains an [`.editorconfig`](https://github.com/rainkingventures/lesson.ly/blob/master/.editorconfig) file which specifies most of the syntax conventions (spacing, etc.) we use. Be sure you're using [an Editorconfig plugin](http://editorconfig.org/#download) with your preferred text editor to ensure your code conforms to these conventions.
+The app contains an [`.editorconfig`](https://github.com/lessonly/lesson.ly/blob/master/.editorconfig) file which specifies most of the syntax conventions (spacing, etc.) we use. Be sure you're using [an Editorconfig plugin](http://editorconfig.org/#download) with your preferred text editor to ensure your code conforms to these conventions.
 
 ## General Guidelines
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,11 @@ layout: default
 
 ## .editorconfig
 
-The app contains an [.editorconfig`](https://github.com/rainkingventures/lesson.ly/blob/master/.editorconfig) file which specifies most of the syntax conventions (spacing, etc.) we use. Be sure you're using [an Editorconfig plugin](http://editorconfig.org/#download) with your preferred text editor to ensure your code conforms to these conventions.
+The app contains an [`.editorconfig`](https://github.com/rainkingventures/lesson.ly/blob/master/.editorconfig) file which specifies most of the syntax conventions (spacing, etc.) we use. Be sure you're using [an Editorconfig plugin](http://editorconfig.org/#download) with your preferred text editor to ensure your code conforms to these conventions.
+
+## General Guidelines
+
+- **Don't commit commented-out code.** It's a distraction from the actually functional code. If code is obsolete or non-functional, delete it: we'll always have a record of it in Git.
 
 ## Language-Specific Styles
 

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ The app contains an [`.editorconfig`](https://github.com/rainkingventures/lesson
 
 ## General Guidelines
 
-- **Don't commit commented-out code.** It's a distraction from the actually functional code. If code is obsolete or non-functional, delete it: we'll always have a record of it in Git.
+- **Don't ship commented-out code.** It can be a distraction from the actually functional code. If code is obsolete or non-functional, delete it: we'll always have a record of it in Git.
 
 ## Language-Specific Styles
 


### PR DESCRIPTION
There are few if any good reasons to leave commented out code in a codebase, and plenty of reasons not to (like preserving clarity and avoiding clutter, and the fact that Git keeps an eternal record of anything we delete). Shall we make this a guideline?

(This also fixes a typo in the `.editorconfig` section.)