### PR TITLE
Avoid HTML and view_context methods in decorators

### DIFF
--- a/ruby-style-guide.md
+++ b/ruby-style-guide.md
@@ -315,6 +315,30 @@ used like:
 
 When deciding whether to use a Decorator or a Presenter, consider whether you're adding behavior to *a single object*. If so use a Decorator, otherwise choose a Presenter.
 
+### Avoid HTML in Decorators
+
+Decorators are great for getting logic out of templates, but some things belong in the templates. HTML is one of those things. While it’s possible to call HTML-generating methods like `link_to` or `content_tag` within decorators by passing in the view context...
+
+```erb
+<%= UserDecorator.new(current_user, self).profile_link %>
+```
+
+```ruby
+class UserDecorator < SimpleDelegator
+
+  def initialize(user, view_context)
+    super(user)
+    @view_context = view_context
+  end
+
+  def profile_link
+    @view_context.link_to("Profile", @view_context.user_path(user))
+  end
+end
+```
+
+...this makes decorator objects more complicated, which makes them harder to test, and blurs the line between Ruby objects and HTML templates. It’s a fine line, though: we routinely use decorators to determine which class names to apply. As a general rule, just avoid anything in decorators that you need to pass in a `view_context` to do.
+
 ## Jobs
 
 We use jobs (found in `/jobs`) to perform actions in the background. We have a simple naming convention: `VerbNoun(s)Job`. For example, a job that sends an assignment notification may be called `SendAssignmentNotificationJob` or a job that creates a set of tags may be called `CreateTagsJob`.


### PR DESCRIPTION
@lessonly/developers, we've been using decorator objects for a while and have started to settle on some conventions for how to use them. One that I've noticed (after initially breaching it myself in `TriggerDecorator`) is having a boundary between decorator logic and template logic at the point of generating HTML tags. In light of that, here's what I propose we add to the styleguide's section on decorators:

![screen shot 2016-04-10 at 3 28 42 pm](https://cloud.githubusercontent.com/assets/664341/14412457/177f8abc-ff31-11e5-84a2-efc0bf1eea68.png)

* * * 

The main justifications being:

- passing in a `view_context` feels like [feature envy](http://programmers.stackexchange.com/questions/212128/what-is-a-feature-envy-code-and-why-is-it-considered-a-code-smell): if the view has to pass itself into a decorator for the decorator to do something, maybe that something is the view's job after all
- Passing in a `view_context` makes decorators harder to test: you have to mock it and stub out any methods called on the `view_context` object. It's not too hard, but still adds complexity.
- Single Responsibility Principle: it seems fairly clear the job of an ERB template is generating HTML markup. I feel that a decorator object shouldn't *also* have that responsibility, especially when it has another responsibility of its own: wrapping a model instance to answer presentation-related methods.

Fixes #32