### PR TITLE
Add suggestions on when to use keyword arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site
 .sass-cache
+.jekyll-metadata

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       sawyer (~> 0.6.0, >= 0.5.3)
     public_suffix (1.5.3)
     rb-fsevent (0.9.7)
-    rb-inotify (0.9.6)
+    rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rdiscount (2.1.8)
     redcarpet (3.3.3)
@@ -127,4 +127,4 @@ DEPENDENCIES
   jekyll (~> 3.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/ruby-style-guide.md
+++ b/ruby-style-guide.md
@@ -135,6 +135,22 @@ These override either Github’s or Batsov’s styleguide where applicable:
     .present?
   ```
 
+- Prefer keyword arguments whenever it isn’t abundantly obvious what an argument is.
+
+  ```ruby
+  # The method name makes it clear what the argument is...
+  # no need to name the argument.
+  def assignment_status(assignment)
+
+  # Even with multiple arguments, if the method name makes
+  # the order clear, no need to name the arguments.
+  def add_user_to_groups(user, groups)
+
+  # But when the method name gives little hint of the type of argument,
+  # specify them by name for maximum clarity.
+  def notify_of_new_assignments(user:, new_assignments:)
+  ```
+
 ## Service Objects
 
 We use the service object pattern to encapsulate complex logic within self-contained objects. Instead of a 20-line controller action, we’ll call `DoSomethingComplicated.perform(args)` in the controller and move all of the complex logic into the `DoSomethingComplicated` class. This not only helps organize and isolate complex code, but also makes it easier to test.


### PR DESCRIPTION

![screen shot 2016-06-09 at 5 51 15 pm](https://cloud.githubusercontent.com/assets/664341/15947669/c90ddcb2-2e6a-11e6-92a0-d7182b0587bd.png)


Resolves #50. This has come up before, and [this Flowdock discussion](https://www.flowdock.com/app/lessonly/development/threads/LA6IwkfyFaJ-4HG51cT3e5lVF4J) prompted me to add it to the styleguide.

@baldwindavid, it sounds like you're on board. @lessonly/developers, thoughts?

Also:

- ignore the new .jekyll-metadata file, per Jekyll’s suggestion: https://github.com/jekyll/jekyll/issues/3595#issuecomment-83784543
- `bundle update rb-fsevent` because the version we had got yanked:

![screen shot 2016-06-09 at 5 47 16 pm](https://cloud.githubusercontent.com/assets/664341/15947570/39073d0c-2e6a-11e6-9a50-c7334e3be118.png)
