### PR TITLE
Date and Time parsing advice

### DIFF
--- a/rails-style-guide.md
+++ b/rails-style-guide.md
@@ -89,3 +89,5 @@ end
 ### Time Zones
 
 Prefer `Time.current` and `Date.current` in place of `Time.now` and `Date.today`. The `.current` methods will properly take the `Time.zone` into account if set, which `.now` and `.today` do not, leading to inconsistent behavior.
+
+Likewise with parsing, avoid `Time.parse` and `Date.parse` (which also don’t account for timezones), and instead prefer `Time.zone.parse` if you need a `Time` object, and calling `to_date` on the result if you need a `Date`.


### PR DESCRIPTION
`Date.parse` (which ignores timezones and parses dates into the *server* timezone, not our *application's* timezone of Eastern, which we generally expect) has given us a lot of headaches in the past with time zone issues in the app and specs.

For that reason, we should always use the (unfortunately more verbose) `Time.zone.parse(string).to_date` when you really want a `Date` object, though the `Time` returned by `Time.zone.parse(string)` will often do as well.

We have [a note about time zones in our styleguide](http://lessonly.github.io/rails/#time-zones) but don't mention parsing. I want to fix that.