### PR TITLE
Append a link to headings for easy referencing!

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,4 +17,34 @@
 
   </body>
 
+  <script>
+    var anchorForId = function (id) {
+      var anchor = document.createElement("a");
+      anchor.className = "header-link";
+      anchor.href      = "#" + id;
+      anchor.innerHTML = "<i class=\"heading-link\">#</i>";
+      return anchor;
+    };
+
+    var linkifyAnchors = function (level, containingElement) {
+      var headers = containingElement.getElementsByTagName("h" + level);
+      for (var h = 0; h < headers.length; h++) {
+        var header = headers[h];
+        console.log(header);
+
+        if (typeof header.id !== "undefined" && header.id !== "") {
+          header.appendChild(anchorForId(header.id));
+        }
+      }
+    };
+
+    document.onreadystatechange = function () {
+      if (this.readyState === "complete") {
+        for (var level = 2; level <= 6; level++) {
+          linkifyAnchors(level, document.body);
+        }
+      }
+    };
+  </script>
+
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,34 +17,6 @@
 
   </body>
 
-  <script>
-    var anchorForId = function (id) {
-      var anchor = document.createElement("a");
-      anchor.className = "header-link";
-      anchor.href      = "#" + id;
-      anchor.innerHTML = "<i class=\"heading-link\">#</i>";
-      return anchor;
-    };
-
-    var linkifyAnchors = function (level, containingElement) {
-      var headers = containingElement.getElementsByTagName("h" + level);
-      for (var h = 0; h < headers.length; h++) {
-        var header = headers[h];
-        console.log(header);
-
-        if (typeof header.id !== "undefined" && header.id !== "") {
-          header.appendChild(anchorForId(header.id));
-        }
-      }
-    };
-
-    document.onreadystatechange = function () {
-      if (this.readyState === "complete") {
-        for (var level = 2; level <= 6; level++) {
-          linkifyAnchors(level, document.body);
-        }
-      }
-    };
-  </script>
+  <script src="/js/main.js"></script>
 
 </html>

--- a/_sass/_linked-headings.scss
+++ b/_sass/_linked-headings.scss
@@ -1,0 +1,5 @@
+.heading-link {
+  font-style: normal;
+  color: #ccc;
+  margin-left: .25em;
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -48,5 +48,6 @@ $on-laptop:        800px;
 @import
         "base",
         "layout",
-        "syntax-highlighting"
+        "syntax-highlighting",
+        "linked-headings"
 ;

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,28 @@
+// Append links to markdown headings
+var anchorForId = function (id) {
+  var anchor = document.createElement("a");
+  anchor.className = "header-link";
+  anchor.href      = "#" + id;
+  anchor.innerHTML = "<i class=\"heading-link\">#</i>";
+  return anchor;
+};
+
+var linkifyAnchors = function (level, containingElement) {
+  var headers = containingElement.getElementsByTagName("h" + level);
+  for (var h = 0; h < headers.length; h++) {
+    var header = headers[h];
+    console.log(header);
+
+    if (typeof header.id !== "undefined" && header.id !== "") {
+      header.appendChild(anchorForId(header.id));
+    }
+  }
+};
+
+document.onreadystatechange = function () {
+  if (this.readyState === "complete") {
+    for (var level = 2; level <= 6; level++) {
+      linkifyAnchors(level, document.body);
+    }
+  }
+};


### PR DESCRIPTION
## Why

We often reference our styleguide in PRs to provide context and additional detail for our suggestions and recommendations, and want to link to particular rules. Jekyll makes that possible, but not easy, by automatically generating linkable `id`s for each of our rules/headings:

<img width="515" alt="screen shot 2017-07-18 at 12 14 25 pm" src="https://user-images.githubusercontent.com/664341/28327926-de781d20-6bb2-11e7-80e6-2892f61f0dd7.png">

Unfortunately, that means we need to inspect the source, copy the `id`, and append it as a fragment identifier to our styleguide links—and who has time for that?!

## What

This PR adds some Javascript (which I [ripped off from the creator of Jekyll](http://blog.parkermoore.de/2014/08/01/header-anchor-links-in-vanilla-javascript-for-github-pages-and-jekyll/)) that appends a link to all of our `h2` through `h6` headings which links to the heading itself:

<img width="814" alt="screen shot 2017-07-18 at 12 12 50 pm" src="https://user-images.githubusercontent.com/664341/28328044-339d04a0-6bb3-11e7-8360-2cad1059ed23.png">

Now, if you want to link someone to a particular rule in the styleguide, just click the `#` link and copy the URL from your browser bar.

## Alternatives Considered

It would be even awesomer if clicking the `#` auto-copied the link for you, but I'm not a JS wizard. I think this is an improvement, and I'm happy with it. I hope you will be too! 😄 