### PR TITLE
Recommend not stubbing *private* methods specifically

### DIFF
--- a/_styleguide/testing.md
+++ b/_styleguide/testing.md
@@ -63,9 +63,9 @@ expect(User.find_by(name: 'John Doe').name).to eq 'John Doe' # This line hits th
 
 ## Guidelines
 
-### Don't stub methods on the class being tested.
+### Don't stub private methods on the class being tested.
 
-[Read why](https://robots.thoughtbot.com/don-t-stub-the-system-under-test).
+`private` methods are private for a reason. When external callers (even tests) refer to them, it makes it harder to refactor. [Learn more](https://robots.thoughtbot.com/don-t-stub-the-system-under-test). You may, however, consider stubbing a public method on a class when testing another method that depends on it, in order to reduce duplication of logic within tests.
 
 ### Avoid stubbing and mocking in integration tests.
 


### PR DESCRIPTION
...in tests. This comes from [this discussion on a PR](https://github.com/lessonly/lessonly/pull/4141/files/6f42718d9ba9dac9c0219cfca41b854474de52f6#r139775382):

> We [advise against stubbing methods](http://lessonly.github.io/styleguide/testing/#dont-stub-methods-on-the-class-being-tested) on the class being tested in the style guide, but the rationale behind that (which comes from [this blog post](https://robots.thoughtbot.com/don-t-stub-the-system-under-test)) really only applies to *private* methods. If `library_paths_for_lesson` is public (and thus has its own tests), I think it's fine stubbing it in specs for other methods, especially when the cost of not doing so is duplicated testing logic. What do you think?