### PR TITLE
Add documentation for PrivateAttr, and clockwork

### DIFF
--- a/styleguide/ruby.md
+++ b/styleguide/ruby.md
@@ -189,3 +189,51 @@ The latter introduces load order dependencies (`MyModule` must already be loaded
 ## Gemfile
 
 We try to use [pessimistic version constraints](http://guides.rubygems.org/patterns/#pessimistic-version-constraint) for all gems in the Gemfile. These use the `~>` operator followed by at least a major and minor gem version (e.g. `"~> 4.2"`). This prevents a gem from being accidentally upgraded by more than a minor version, and Gems following [Semantic Versioning](http://semver.org/) promise to introduce non-backwards-compatible changes only in major versions.
+
+## PrivateAttr vs private attr_reader vs instance variables
+
+Currently in the code there are three styles of accessors:
+ - Use of `PrivateAttr`
+ - Use of `private` with accessors below
+ - Just using instance variables for information hiding
+
+Some of the differences are described below. For declaring private accessors, both the PrivateAttr and having the `attr_reader` below `private` are acceptable options. Using instance variables should be avoided.
+
+### PrivateAttr
+
+The PrivateAttr functionality was added via [PR #2787](https://github.com/lessonly/lessonly/pull/2787) as a way to limit the public interface and use private methods rather than instance variables. One of the advantages of using PrivateAttr is that all of the instance variables will be listed at the top of the file for clarity.
+```
+class MyClass
+  extend PrivateAttr
+
+  private_attr_reader :foo, :bar, :baz
+
+  initialize(foo, bar, baz) do
+    @foo = foo
+    @bar = bar
+    @baz = baz
+  end
+```
+
+### private attr_reader
+
+The same thing can be accomplished by placing the `attr_reader` below `private`. One of the disadvantages is that in large files it can be easy to overlook the `attr_reader` that is somewhere below `private` in the middle of the code.
+```
+class MyClass
+
+  initialize(foo, bar, baz) do
+    @foo = foo
+    @bar = bar
+    @baz = baz
+  end
+
+  private
+
+  attr_reader :foo, :bar, :baz
+```
+
+### instance variables
+
+Use of instance variables should be avoided.
+
+See the "Writing Code That Embraces Change" section in Chapter 2 of Sandi Metz's [_Practical Object Oriented Design in Ruby_](https://drive.google.com/a/lessonly.com/file/d/0BxpjY5cIh-FFZU84Q3p1VTNMQXM/view), for reasons to use private methods rather than instance variables. Specifically, about wrapping all instance variables in reader and/or writer methods with `attr_reader`, `attr_writer`, or `attr_accessor`, and if these methods don't need to be public then making them private.

--- a/styleguide/ruby.md
+++ b/styleguide/ruby.md
@@ -197,7 +197,9 @@ Currently in the code there are three styles of accessors:
  - Use of `private` with accessors below
  - Just using instance variables for information hiding
 
-Some of the differences are described below. For declaring private accessors, both the PrivateAttr and having the `attr_reader` below `private` are acceptable options. Using instance variables should be avoided.
+`PrivateAttr` is the preferred method for declaring private accessors even though both PrivateAttr and having the `attr_reader` below `private` accomplish the same thing. This is for consistency, so everything is defined in one place within the file (at the top). Using instance variables should be avoided.
+
+Some of the differences are described below:
 
 ### PrivateAttr
 

--- a/styleguide/ruby/job.md
+++ b/styleguide/ruby/job.md
@@ -68,3 +68,16 @@ end
 ```
 
 In this case, if `OldJob` is already queued, it will still run as it extends `NewJob`.
+
+### Scheduling a job
+
+Lessonly uses clockwork to schedule background jobs. The job will need to be added to `lib/clock.rb`.
+
+To kick-off the background job from the command line:
+```
+bundle exec clockwork lib/clock.rb
+```
+
+Note:
+ - May need to restart the server before running the command.
+ - At some point we may get rid of clockwork and replace with sidekiq scheduled jobs

--- a/styleguide/ruby/job.md
+++ b/styleguide/ruby/job.md
@@ -78,6 +78,10 @@ To kick-off the background job from the command line:
 bundle exec clockwork lib/clock.rb
 ```
 
+Useful links:
+ - [Clockwork gem](https://github.com/adamwiggins/clockwork)
+ - [Gem for testing clockwork](https://github.com/kevin-j-m/clockwork-test)
+
 Note:
- - May need to restart the server before running the command.
+ - May need to restart the server before running the command
  - At some point we may get rid of clockwork and replace with sidekiq scheduled jobs

--- a/styleguide/ruby/job.md
+++ b/styleguide/ruby/job.md
@@ -79,7 +79,8 @@ bundle exec clockwork lib/clock.rb
 ```
 
 Useful links:
- - [Clockwork gem](https://github.com/adamwiggins/clockwork)
+ - [Clockwork gem](https://rubygems.org/gems/clockwork/versions/1.3.1)
+ - [Clockwork gem documentation](https://www.rubydoc.info/gems/clockwork/1.3.1)
  - [Gem for testing clockwork](https://github.com/kevin-j-m/clockwork-test)
 
 Note:


### PR DESCRIPTION
Resolves [ch17240](https://app.clubhouse.io/lessonly/story/17240)
Based on [this](https://lessonly.slack.com/archives/G8Q5B0EVA/p1533828056000603) slack conversation, added a section in ruby.md around private accessors.

Also added a section in the Jobs documentation around how to schedule the background job.