### PR TITLE
Update styleguide to reflect newly enabled robocop-rspec checks

### DIFF
--- a/styleguide/testing.md
+++ b/styleguide/testing.md
@@ -331,3 +331,123 @@ end
 it "creates an answer with the description as the answer" do
 end
 ```
+
+### Include an empty line after an example group
+```ruby
+# bad
+RSpec.describe Foo do
+  describe '#bar' do
+  end
+  describe '#baz' do
+  end
+end
+
+# good
+RSpec.describe Foo do
+  describe '#bar' do
+  end
+
+  describe '#baz' do
+  end
+end
+```
+
+### Include an empty line after hook blocks
+```ruby
+# bad
+before { do_something }
+it { does_something }
+
+# bad
+after { do_something }
+it { does_something }
+
+# bad
+around { |test| test.run }
+it { does_something }
+
+# good
+before { do_something }
+
+it { does_something }
+
+# good
+after { do_something }
+
+it { does_something }
+
+# good
+around { |test| test.run }
+
+it { does_something }
+```
+
+### When using the change matcher, pass in an object and attribute as arguments
+```ruby
+# bad
+expect(run).to change { Foo.bar }
+expect(run).to change { foo.baz }
+
+# good
+expect(run).to change(Foo, :bar)
+expect(run).to change(foo, :baz)
+# also good when there are arguments or chained method calls
+expect(run).to change { Foo.bar(:count) }
+expect(run).to change { user.reload.name }
+```
+
+### Use local variables or 'let' instead of instance variables
+```ruby
+# bad
+describe MyClass do
+  before { @foo = [] }
+  it { expect(@foo).to be_empty }
+end
+
+# good
+describe MyClass do
+  let(:foo) { [] }
+  it { expect(foo).to be_empty }
+end
+```
+
+### Use 'all' matcher instead of iterating over an array
+```ruby
+# bad
+it 'validates users' do
+  [user1, user2, user3].each { |user| expect(user).to be_valid }
+end
+
+# good
+it 'validates users' do
+  expect([user1, user2, user3]).to all(be_valid)
+end
+```
+
+### 'let' statements should come before examples
+```ruby
+# Bad
+let(:foo) { bar }
+
+it 'checks what foo does' do
+  expect(foo).to be
+end
+
+let(:some) { other }
+
+it 'checks what some does' do
+  expect(some).to be
+end
+
+# Good
+let(:foo) { bar }
+let(:some) { other }
+
+it 'checks what foo does' do
+  expect(foo).to be
+end
+
+it 'checks what some does' do
+  expect(some).to be
+end
+```


### PR DESCRIPTION
## Why?

Resolves [[ch21408]](https://app.clubhouse.io/lessonly/story/21408)

A number of robocop-rspec checks have been enabled. Not all of the checks were documented in the style guide. This PR adds the expectations for these checks to the testing styleguide.

## What?
* Include an empty line after an example group. Corresponds to rubocop-rspec RSpec/EmptyLineAfterExampleGroup
* Include an empty line after hook blocks. Corresponds to rubocop-rspec RSpec/EmptyLineAfterHook
* When using the change matcher, pass in an object and attribute as arguments. Corresponds to rubocop-rspec RSpec/ExpectChange
* Use local variables or 'let' instead of instance variables.
Corresponds to rubocop-rspec RSpec/InstanceVariable
* Use 'all' matcher instead of iterating over an array. Corresponds to
rubocop-rspec RSpec::IteratedExpectation
* 'let' statements should come before examples. Corresponds to
rubocop-rspec RSpec::LetBeforeExamples