### PR TITLE
Remove irrelevant javascript translation rules

### DIFF
--- a/_styleguide/translations.md
+++ b/_styleguide/translations.md
@@ -8,8 +8,6 @@ main: true
 
 #### Avoid using I18n within constants
 
-**Ruby context**
-
 ```ruby
 # Avoid
 # This is evaluated once at load time and will always be in the default language (English).

--- a/_styleguide/translations.md
+++ b/_styleguide/translations.md
@@ -21,22 +21,3 @@ def error_message
   I18n.t("common.error")
 end
 ```
-
-**JavaScript context**
-
-```javascript
-// Avoid
-// This is hardcoded at build time, before translations are even loaded.
-const ERROR_MESSAGE = t('common.error');
-
-// Recommended
-// This is evaluated every time with the locale of the current request.
-const errorMessage = () => t('common.error');
-
-// or with a getter function
-const MESSAGES = {
-  get ERROR() {
-    return t('common.error');
-  }
-};
-```


### PR DESCRIPTION
This section is no longer relevant. This was resolved in [ch24334].

You should now be able to use the javascript `t()` however you want. Even outside of a React render method or before the page is fully loaded.