### PR TITLE
Add another option for active record model validation messages

### DIFF
--- a/_styleguide/translations.md
+++ b/_styleguide/translations.md
@@ -19,3 +19,17 @@ def error_message
   I18n.t("common.error")
 end
 ```
+
+#### Avoid using I18n outside of a method or lambda
+
+```rb
+# Avoid
+# This is evaluated once at load time and will always be in the default language (English).
+validates :name, presence: { message: I18n.t("common.error") }
+
+# Recommended
+# This is evaluated every time it's called with the locale of the current request.
+# `record` is the ActiveRecord::Base instance with the validation error.
+# `attribute` is a hash of information about the attribute being validated.
+validates :name, presence: { message: ->(record, attribute) { I18n.t("common.error") } }
+```


### PR DESCRIPTION
This file already contains great information about preloading translations directly into English. I stumbled into a similar pattern we're using which also preloads the English translation for error messages.

This PR adds another "Avoid" example and a "Recommended" example to go along with it.