### PR TITLE
New post: “How we Hire Engineers”

### DIFF
--- a/_posts/2019-08-09-how-we-hire-engineers.md
+++ b/_posts/2019-08-09-how-we-hire-engineers.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title: "How We Hire Engineers"
+---
+
+Lessonly is on a mission to help people do better work so they can live better lives. On the Product Team, we build and support software used by millions of learners (including us!) to find the resources they need to be great at their jobs. If that’s a mission you’re inspired to contribute to, we’d love for you to join us.
+
+It honors us when someone wants to work with us, so we strive to make applying to Lessonly a fair, clear, and enjoyable process, and a learning experience for both you and us. You’ll talk to humans throughout the process, and we encourage questions at any point.
+
+We believe [clarity is kindness](https://brenebrown.com/articles/2018/10/15/clear-is-kind-unclear-is-unkind/), so we’d like to be clear about what to expect when applying.
+
+## A Walk Through Our Hiring Process
+
+### 1. Apply
+
+The first step is to **tell us a bit about yourself** by applying to one of the positions on [lessonly.com/hiring](https://www.lessonly.com/hiring/). If you’re excited to work with us and don’t see a role that fits, we’d still love to hear from you. We keep a "Tell us about yourself" position open at all times for that. You can expect a follow-up from someone on our team within a few days.
+
+### 2. Complete a Work Simulation Through Woven
+
+For engineering roles, the next step is what we call a **"work simulation"**. We’ve partnered with the team at [Woven](https://www.woventeams.com/) to craft a set of real-world coding and communication scenarios for each role. We ask 60-90 minutes of your time to complete these online. Our goal with this step is to give you a feel for the job and a level playing field on which to demonstrate your abilities, since these are scored anonymously on a standardized rubric. In exchange for your time, you’ll receive feedback on your submissions.
+
+### 3. Talk With a Teammate
+
+The next step is a **30-minute phone interview** with someone on the team you’d be working with. The goal of this conversation is to help you understand who you could be on our team, and to help us understand what our team could be with you on it. You’ll have plenty of opportunity to ask questions. What we look for most at this stage are the attributes of an [ideal team player](https://www.tablegroup.com/books/ideal-team-player): humble, hungry, and people-smart. Humility because we work collaboratively: the strength of a team transcends any one member. Hunger (meaning a desire to learn and grow) because we’re always looking for ways to [do better work](http://dobetter.work). And people-smarts (self-awareness and empathy) because everything depends on an environment of psychological safety and mutual respect.
+
+### 4. Visit the Office
+
+The next-to-last stage is an **on-site interview** at our Indianapolis office. For this we ask 3 hours of your time to come tour our office and meet a half-dozen folks you’d likely be working with for a series of four conversations: a tech talk with fellow engineers (no whiteboards, just words); a culture chat; a conversation with HR about the company, benefits, and such; and a final interview with the hiring manager and our Head of Product to answer any remaining questions.
+
+For the on-site interview, we’ll do all we can to accommodate your schedule. If interviews happen between 12 and 1pm, we’ll provide lunch. And we encourage you to dress comfortably, whatever that means to you. Most of us wear T-shirts around the office with the occasional blouse or button-down.
+
+### 5. Accept an Offer
+
+Finally, if we’re confident that you and Lessonly would be better together, we’ll **extend an offer**, which includes a total compensation package and title. While we’ll likely have asked about a potential start date by now, at this point we’ll seek to finalize that. And if you accept, we’ll let the team know with copious 🎉 emoji and prepare for your arrival and onboarding!


### PR DESCRIPTION
# Why

We want to provide the best experience possible to folks who pay us the compliment of wanting to work alongside us. That starts with clarity about the application process itself.

# What

This is a blog post outlining our hiring process, which we can link to from job postings or applicant emails so folks can be prepared. In particular, the post aims to communicate as clearly as possible:

- What happens at each stage
- Why that stage exists (so we're not wasting peoples' time)