### PR TITLE
Add link hover and active styles

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -77,6 +77,10 @@
   align-items: center;
   .page-link {
     margin-right: 16px;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
   @include media-query($phone) {
     display: none;
@@ -284,6 +288,9 @@
   .language {
     border-bottom: 1px solid $grey-color-light;
 
+    &:hover {
+      background-color: $brand-color-lightest;
+    }
     &.active {
       background: $brand-color-lightest;
     }
@@ -321,6 +328,17 @@
   }
   h6 {
     font-size: 1.1em;
+  }
+  i {
+    transition: color 225ms ease;
+  }
+  a {
+    text-decoration: underline;
+    transition: color 225ms ease;
+
+    &:hover, &:hover i {
+      color: $brand-color;
+    }
   }
 }
 


### PR DESCRIPTION
Link styles aren't really useful right now in the styleguide, sidebar, and navigation. This makes them work again.

![link-styling](https://user-images.githubusercontent.com/956570/68033571-57369680-fc96-11e9-944b-6324187caa60.gif)
