### PR TITLE
Update our recommendation around foreign-key constraints

### DIFF
--- a/_styleguide/database.md
+++ b/_styleguide/database.md
@@ -8,13 +8,13 @@ main: true
 
 The PostgreSQL Wiki has a handy [“Don’t Do This”](https://wiki.postgresql.org/wiki/Don't_Do_This) page. While there are exceptions when most of these discouraged practices may be safe or even necessary, we should avoid them unless we’re sure we’re the exception.
 
-## Enforce data integrity at the database level whenever possible.
+## Enforce data integrity with unique indexes and not-null constraints
 
 PostgreSQL gives us a range of tools to ensure invalid data isn’t just unlikely but impossible:
 
 - Use `UNIQUE` `CONSTRAINT`s/`INDEX`es (`unique: true` in migrations) to prohibit “duplicate” data. For instance, if it doesn’t make sense for a Lesson to be tagged with “Sales” _twice_, we want a unique composite index on the `tag` and `taggable`.
 - Use `NOT NULL` (`null: false` in migrations) to guarantee necessary relationships (e.g. make `company_id` non-nullable on tables that must be associated with a company) or attributes (if a `title` is required, make it `NOT NULL`).
-- Use `FOREIGN KEY` constraints to ensure that references to other tables like `company_id` point to records that actually exist, and specify `ON DELETE` `CASCADE` or `NULLIFY` behaviors when those records are removed. (Be mindful of performance when adding foreign key constraints: see [this migration](https://github.com/lessonly/lessonly/pull/5390/files#diff-bf0c0f95fbacafc133567b5e36e2f289R20) for an illustration the challenges and a way around them.)
+- **Update:** we no longer recommend adding `FOREIGN KEY` constraints by default, as we’ve run into performance issues on tables like `users` that have very many of them. However, we should still consider them in cases where referential integrity is essential. (And be mindful of performance when adding foreign key constraints: see [this migration](https://github.com/lessonly/lessonly/pull/5390/files#diff-bf0c0f95fbacafc133567b5e36e2f289R20) for an illustration of the challenges and a way around them.)
 
 Bugs resulting from invalid data can be tricky to detect and it can be time-consuming to clean up—best to prevent the possibility of it in the first place.
 

--- a/_styleguide/database.md
+++ b/_styleguide/database.md
@@ -14,7 +14,7 @@ PostgreSQL gives us a range of tools to ensure invalid data isn’t just unlikel
 
 - Use `UNIQUE` `CONSTRAINT`s/`INDEX`es (`unique: true` in migrations) to prohibit “duplicate” data. For instance, if it doesn’t make sense for a Lesson to be tagged with “Sales” _twice_, we want a unique composite index on the `tag` and `taggable`.
 - Use `NOT NULL` (`null: false` in migrations) to guarantee necessary relationships (e.g. make `company_id` non-nullable on tables that must be associated with a company) or attributes (if a `title` is required, make it `NOT NULL`).
-- **Update:** we no longer recommend adding `FOREIGN KEY` constraints by default, as we’ve run into performance issues on tables like `users` that have very many of them. However, we should still consider them in cases where referential integrity is essential. (And be mindful of performance when adding foreign key constraints: see [this migration](https://github.com/lessonly/lessonly/pull/5390/files#diff-bf0c0f95fbacafc133567b5e36e2f289R20) for an illustration of the challenges and a way around them.)
+- **Update:** we no longer recommend adding `FOREIGN KEY` constraints, as we’ve run into performance issues on tables like `users` that have very many of them. So avoid adding foreign-key constraints unless there is an overriding concern about data fidelity to justify them. (If so, be mindful of performance when adding foreign key constraints: see [this migration](https://github.com/lessonly/lessonly/pull/5390/files#diff-bf0c0f95fbacafc133567b5e36e2f289R20) for an illustration of the challenges and a way around them.)
 
 Bugs resulting from invalid data can be tricky to detect and it can be time-consuming to clean up—best to prevent the possibility of it in the first place.
 


### PR DESCRIPTION
<img width="1117" alt="Screen Shot 2020-12-02 at 10 56 57 AM" src="https://user-images.githubusercontent.com/664341/100896890-1a3a6600-348d-11eb-9d22-2f683232b944.png">

# What

We used to recommend always enforcing referential integrity in the database with `FOREIGN KEY` constraints, but ran into performance issues with the `users` table having 60+ of them and deleting users being unsustainably slow as a result. We now recommend not using FK constraints unless we have a compelling reason to.

# See Also

- Initial [post in Slack](https://lessonly.slack.com/archives/G8Q5B0EVA/p1594301004090400) about the moratorium
- Slack post [on this Style Guide/Lesson update](https://lessonly.slack.com/archives/C8LGVESDC/p1606858496380100)